### PR TITLE
use prettier by default

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "requirePragma": true,
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,

--- a/example/index.js
+++ b/example/index.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/js/ProgressViewIOS.android.js
+++ b/js/ProgressViewIOS.android.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  */
 
 'use strict';

--- a/js/ProgressViewIOS.ios.js
+++ b/js/ProgressViewIOS.ios.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/js/RNCProgressViewNativeComponent.js
+++ b/js/RNCProgressViewNativeComponent.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @format
  */
 
 'use strict';

--- a/js/__tests__/ProgressViewIOS.ios.test.js
+++ b/js/__tests__/ProgressViewIOS.ios.test.js
@@ -10,13 +10,17 @@ describe('<ProgressView />', () => {
   });
 
   it('renders Horizontal ProgressView', () => {
-    const tree = renderer.create(<ProgressView progressViewStyle="bar" />).toJSON();
+    const tree = renderer
+      .create(<ProgressView progressViewStyle="bar" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders ProgressView with tintColor', () => {
-    const tree = renderer.create(<ProgressView progressTintColor="red" />).toJSON();
+    const tree = renderer
+      .create(<ProgressView progressTintColor="red" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@babel/runtime": "^7.4.3",
-    "@react-native-community/eslint-config": "^0.0.6",
+    "@react-native-community/eslint-config": "^0.0.7",
     "@react-native-community/eslint-plugin": "^1.0.0",
     "@types/react": "^16.9.19",
     "@types/react-native": "^0.61.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,11 +1158,12 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
-"@react-native-community/eslint-config@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-0.0.6.tgz#9f1dffde994a14db7504a969f21cdf49f470eb34"
-  integrity sha512-jtMZ1fzYYykrllbTCATZ8n5HS6Npwv9gusPk/+lMUBrmLXolGFiHFJQIpdcQzWFQb6POigAxo0O+xSiwlsT7Rw==
+"@react-native-community/eslint-config@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-0.0.7.tgz#2a91d336b413d8c77ac5fa634b66703f481243ac"
+  integrity sha512-khKxg3BMsXZYSXLat0ygSqTM0KdgciK+gm+hGecM7HzQA10hNTKeMmoFNiNxV+M/5PUyTsnRAz4RtWPVWLuPfQ==
   dependencies:
+    "@react-native-community/eslint-plugin" "^1.0.0"
     "@typescript-eslint/eslint-plugin" "^1.5.0"
     "@typescript-eslint/parser" "^1.5.0"
     babel-eslint "10.0.3"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I removed `"requirePragma": true` from `prettierrc` because that option means prettier is not enabled unless explicitly turned on using the `@format` pragma.

After that I just ran `eslint --fix` and the code now follows the specified config.


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

- eslint passes (it does locally :) )

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
